### PR TITLE
Fix bullet vs enemy collision priority

### DIFF
--- a/index.html
+++ b/index.html
@@ -1257,6 +1257,34 @@
                     continue;
                 }
 
+                let bulletRemoved = false;
+
+                // Check collision with ENEMIES first
+                for (let j = enemies.length - 1; j >= 0; j--) {
+                    const enemy = enemies[j];
+                    if (bullet.position.distanceTo(enemy.position) < bullet.userData.radius + enemy.userData.radius) {
+                        // Remove enemy
+                        scene.remove(enemy);
+                        enemies.splice(j, 1);
+
+                        // Remove bullet
+                        scene.remove(bullet);
+                        bullets.splice(i, 1);
+
+                        // Reproducir sonido de enemigo eliminado
+                        playSound('Enemigo_Eliminado');
+
+                        // Add score
+                        score += 10;
+                        updateUI();
+
+                        bulletRemoved = true;
+                        break;
+                    }
+                }
+
+                if (bulletRemoved) continue;
+
                 // Check collision with ROCKS
                 for (const obstacle of obstacles) {
                     if (bullet.position.distanceTo(obstacle.position) < bullet.userData.radius + obstacle.userData.radius) {
@@ -1264,31 +1292,7 @@
                         bullets.splice(i, 1);
                         // Reproducir sonido de colisión con rocas
                         playSound('Colision_con_Rocas');
-                        break;
-                    }
-                }
-                
-                // Check if bullet was removed due to rock collision
-                if (i >= bullets.length) continue;
-                
-                // Check collision with ENEMIES
-                for (let j = enemies.length - 1; j >= 0; j--) {
-                    const enemy = enemies[j];
-                    if (bullet.position.distanceTo(enemy.position) < bullet.userData.radius + enemy.userData.radius) {
-                        // Remove enemy
-                        scene.remove(enemy);
-                        enemies.splice(j, 1);
-                        
-                        // Remove bullet
-                        scene.remove(bullet);
-                        bullets.splice(i, 1);
-                        
-                        // Reproducir sonido de enemigo eliminado
-                        playSound('Enemigo_Eliminado');
-                        
-                        // Add score
-                        score += 10;
-                        updateUI();
+                        bulletRemoved = true;
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure bullets handle enemy collision before rocks so both checks happen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f4138fdb4832d9c7b71a4e51e3bd8